### PR TITLE
Feature/server/command 31

### DIFF
--- a/src/main/java/com/mafiachat/protocol/Command.java
+++ b/src/main/java/com/mafiachat/protocol/Command.java
@@ -11,8 +11,10 @@ public enum Command {
 
     //Game 관련
     READY,
+    NOTIFY_ROLE,
     PLAYER_LIST,
     VOTE,
+    VOTED_LIST,
     ACT_ROLE,
 
     //phase notify 커맨드


### PR DESCRIPTION
### feat: 플레이어 역할 노티, 뽑힌 플레이어 리스트 커맨드 Enum 추가

- NOTIFY_ROLE: 서버에서 각 유저 별 역할 알려주는 커맨드.
- VOTED_LIST: 투표된 사람 목록 알려주는 커맨드.

### feat: 플레이어 역할 노티, 뽑힌 플레이어 리스트 커맨드 로직 추가

- announceRole(): 서버에서 각 유저 별 역할 알려주는 로직을 추가.
- startDayDefense(): 투표된 사람 목록 알려주는 로직을 추가.

### 추가된 명세
https://www.notion.so/API-49226b4e614b486fac611558f325d982