### PR TITLE
fix: 게임 결과 메시지 개행을 별개 리퀘스트로 변경

### DIFF
--- a/src/main/java/com/mafiachat/server/manager/GameManager.java
+++ b/src/main/java/com/mafiachat/server/manager/GameManager.java
@@ -400,12 +400,14 @@ public class GameManager {
     }
 
     private void announceResult(GameResult gameResult) {
-        String userRoleList = playerGroup.stream()
+        List<String> userRoleMessages = playerGroup.stream()
                 .map((p) -> "%s(%d) 플레이어는 %s입니다.".formatted(p.getClientName(), p.getId(), p.getRole().description))
-                .collect(Collectors.joining("\n"));
-        String announceMessage = "%s\n%s".formatted(gameResult.announceMessage, userRoleList);
-        ChatRequest request = ChatRequest.createSystemRequest(announceMessage);
-        groupManager.broadcastMessage(request);
+                .toList();
+        for (String userRoleMessage: userRoleMessages) {
+            String announceMessage = "%s\n%s".formatted(gameResult.announceMessage, userRoleMessage);
+            ChatRequest request = ChatRequest.createSystemRequest(announceMessage);
+            groupManager.broadcastMessage(request);
+        }
     }
 
     private GameResult getGameResult() {


### PR DESCRIPTION
"%s(%d) 플레이어는 %s입니다.\n%s(%d) 플레이어는 %s입니다.\n ..."
-> "%s(%d) 플레이어는 %s입니다.", "%s(%d) 플레이어는 %s입니다.", "%s(%d) 플레이어는 %s입니다." ...