### PR TITLE
Feature/server/test 40

### DIFF
--- a/src/test/java/com/mafiachat/server/handler/Player/PlayerTest.java
+++ b/src/test/java/com/mafiachat/server/handler/Player/PlayerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +42,8 @@ class PlayerTest {
     @Mock
     private GameManager gameManager;
 
+    private GameManager spyGameManager;
+
     private Player player;
 
     @BeforeEach
@@ -48,6 +51,7 @@ class PlayerTest {
         chatServer = new ChatServer(GroupManager.getInstance(), GameManager.getInstance());
         serverThread = new Thread(chatServer);
         serverThread.start();
+        spyGameManager = spy(GameManager.getInstance());
     }
 
     @BeforeEach
@@ -66,12 +70,13 @@ class PlayerTest {
     public void vote(int voteCount) {
         //given
         ChatRequest request = ChatRequest.createRequest(Command.VOTE, "1");
+        Player player = new Player(spyGameManager);
 
         //when
         player.vote(request);
 
         //then
-        assertEquals(voteCount, GameManager.getInstance().getVoteCountById(1));
+        assertEquals(voteCount, spyGameManager.getVoteCountById(1));
     }
 
     @DisplayName("밤에 시민이 아닌 역할들 대화 테스트")

--- a/src/test/java/com/mafiachat/server/manager/GroupManagerTest.java
+++ b/src/test/java/com/mafiachat/server/manager/GroupManagerTest.java
@@ -56,8 +56,8 @@ public class GroupManagerTest {
     @ParameterizedTest
     @DisplayName("클라 id 자동 생성 테스트")
     @MethodSource("getTestcaseForCreateClientId")
-    public void testCreateClientId(int expectedId) {
-        int id = groupManager.createClientId();
+    public void testCreateClientId(GroupManager spyGroupManager, int expectedId) {
+        int id = spyGroupManager.createClientId();
         assertThat(id).isEqualTo(expectedId);
     }
 
@@ -204,11 +204,12 @@ public class GroupManagerTest {
     }
 
     private Stream<Arguments> getTestcaseForCreateClientId() {
+        GroupManager spyGroupManager = spy(GroupManager.class);
         return Stream.of(
-                Arguments.of(1),
-                Arguments.of(2),
-                Arguments.of(3),
-                Arguments.of(4)
+                Arguments.of(spyGroupManager, 1),
+                Arguments.of(spyGroupManager, 2),
+                Arguments.of(spyGroupManager, 3),
+                Arguments.of(spyGroupManager, 4)
         );
     }
 


### PR DESCRIPTION
### fix: GroupManagerTest 실패 해결

- testCreateClientId(): groupManager를 다른 테스트와 공유하여 의도하지 않은 id 값이 생성되었음. testCreateClientId() 테스트 안에서만 공유되는 spy 객체를 만들어 사용하도록 수정함.

### fix: PlayerTest 실패 해결

- vote(): gameManager를 다른 테스트와 공유하여 의도하지 않은 투표값이 생성되었음. vote() 테스트 안에서만 공유되는 spy 객체를 만들어 사용하도록 수정함.