### PR TITLE
feat: 서버 시작 시 호스트, 포트 받는 다이얼로그 구현

### DIFF
--- a/src/main/java/com/mafiachat/server/ChatServer.java
+++ b/src/main/java/com/mafiachat/server/ChatServer.java
@@ -1,11 +1,14 @@
 package com.mafiachat.server;
 
+import static com.mafiachat.util.Constant.SERVER_HOST;
 import static com.mafiachat.util.Constant.SERVER_PORT;
 
 import com.mafiachat.server.handler.Player.Player;
 import com.mafiachat.server.handler.PlayerHandler;
 import com.mafiachat.server.manager.GameManager;
 import com.mafiachat.server.manager.GroupManager;
+
+import javax.swing.*;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -17,11 +20,13 @@ public class ChatServer implements Runnable {
     private final GameManager gameManager;
     private final ServerSocket serverSocket;
     private static final Logger logger = Logger.getLogger(ChatServer.class.getSimpleName());
+    private static String host = SERVER_HOST;
+    private static int port = SERVER_PORT;
 
     public ChatServer(GroupManager groupManager, GameManager gameManager) throws IOException {
         this.groupManager = groupManager;
         this.gameManager = gameManager;
-        serverSocket = new ServerSocket(SERVER_PORT);
+        serverSocket = new ServerSocket(port, 50, InetAddress.getByName(host));
         logger.info(
                 String.format("ChatServer[%s] is listening on port %s\n", InetAddress.getLocalHost().getHostAddress(),
                         SERVER_PORT));
@@ -57,11 +62,34 @@ public class ChatServer implements Runnable {
     }
 
     public static void main(String[] args) {
+        setHostAndPortUsingDialog();
+        while (!tryRunServer()) {
+            setHostAndPortUsingDialog();
+        }
+        JFrame serverWindow = new JFrame("MafiaStart");
+        serverWindow.setSize(500, 400);
+        serverWindow.setVisible(true);
+        serverWindow.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+    }
+
+    private static boolean tryRunServer() {
+        boolean isRunning = false;
         try {
             Runnable r = new ChatServer(GroupManager.getInstance(), GameManager.getInstance());
             new Thread(r).start();
+            isRunning = true;
         } catch (IOException e) {
             logger.severe("Failed to start server: " + e.getMessage());
+        }
+        return isRunning;
+    }
+
+    private static void setHostAndPortUsingDialog() {
+        try {
+            host = JOptionPane.showInputDialog("접속 호스트를 입력하세요.");
+            port = Integer.parseInt(JOptionPane.showInputDialog("접속 포트를 입력하세요."));
+        } catch (NumberFormatException e) {
+            logger.severe("Invalid input: " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
### feat: 서버 시작 시 호스트, 포트 받는 다이얼로그 구현
- main(): 서버를 UI 상에서 끄기 위한 GUI 창을 표시하도록 추가함.
- setHostAndPortUsingDialog(): 서버 호스트와 포트를 받아오기 위한 다이얼로그를 표시하고 받아온 값을 적용함.
- tryRunServer(): setHostAndPortUsingDialog()로 받아온 호스트, 포트 값으로 서버 구동을 시도함.