### PR TITLE
fix: 게임 2회 차 이후 직업 행동 반영 안되는 서버 버그 수정

### DIFF
--- a/src/main/java/com/mafiachat/server/manager/GameManager.java
+++ b/src/main/java/com/mafiachat/server/manager/GameManager.java
@@ -346,6 +346,7 @@ public class GameManager {
         PlayerHandler mafiaTargetPlayer = role2TargetPlayer.getOrDefault(Role.MAFIA, null);
         PlayerHandler doctorTargetPlayer = role2TargetPlayer.getOrDefault(Role.DOCTOR, null);
         PlayerHandler policeTargetPlayer = role2TargetPlayer.getOrDefault(Role.POLICE, null);
+        role2TargetPlayer.clear();
 
         if (policeTargetPlayer != null) {
             ChatRequest request = ChatRequest.createSystemRequest(


### PR DESCRIPTION
### fix: 게임 2회 차 이후 직업 행동 반영 안되는 서버 버그 수정

- 두 번째 밤부터 직업 행동으로 특정 플레이어를 타겟해도 서버에서 반영 안되고 첫 번째 밤에 지목한 플레이어로 또 지목되는 버그가 있었음.
- role2TargetPlayer: 직업 별 타겟 정보를 저장하는 맵을 직업 행동을 반영하면서 초기화 하도록 변경함.